### PR TITLE
Threaded producer

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -59,6 +59,9 @@ class KafkaConnection(local):
 
         self.reinit()
 
+    def __getnewargs__(self):
+        return (self.host, self.port, self.timeout)
+
     def __repr__(self):
         return "<KafkaConnection host=%s port=%d>" % (self.host, self.port)
 
@@ -135,6 +138,7 @@ class KafkaConnection(local):
         """
         c = copy.deepcopy(self)
         c._sock = None
+        c._dirty = True
         return c
 
     def close(self):


### PR DESCRIPTION
Turned out to be a little more involved than I anticipated, since KafkaConnection had a major bug with copy() and threads (due to subclassing threading.local). As a side effect reinit() is not mandatory anymore, client will automatically reconnect when it is used for the first time after a copy().