### PR TITLE
Support for consumer-aware OffsetFetchRequest and OffsetCommitRequest

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -8,7 +8,7 @@ from itertools import count
 from kafka.common import (ErrorMapping, ErrorStrings, TopicAndPartition,
                           ConnectionError, FailedPayloadsError,
                           BrokerResponseError, PartitionUnavailableError,
-                          LeaderUnavailableError,
+                          LeaderUnavailableError, CoordinatorUnavailableError,
                           KafkaUnavailableError)
 
 from kafka.conn import collect_hosts, KafkaConnection, DEFAULT_SOCKET_TIMEOUT_SECONDS
@@ -61,6 +61,20 @@ class KafkaClient(object):
                 KafkaConnection(broker.host, broker.port, timeout=self.timeout)
 
         return self._get_conn(broker.host, broker.port)
+
+    def _get_coordinator_for_consumer(self, consumer):
+        """
+        Returns the coordinator for a consumer group as BrokerMetadata
+        """
+        request_id = self._next_id()
+        request = KafkaProtocol.encode_consumer_metadata_request(self.client_id,
+                                                                 request_id, consumer)
+
+        response = self._send_broker_unaware_request(request_id, request)
+        broker = KafkaProtocol.decode_consumer_metadata_response(response)
+
+        log.debug("Broker metadata: %s", broker)
+        return broker
 
     def _get_leader_for_partition(self, topic, partition):
         """
@@ -186,6 +200,60 @@ class KafkaClient(object):
 
         # Order the accumulated responses by the original key order
         return (acc[k] for k in original_keys) if acc else ()
+
+    def _send_consumer_aware_request(self, group, payloads, encoder_fn, decoder_fn):
+        """
+        Send requests to the coordinator for the specified consumer group
+
+        Params
+        ======
+        group: the consumer group string for the request
+        payloads: list of object-like entities with a topic and
+                  partition attribute
+        encode_fn: a method to encode the list of payloads to a request body,
+                   must accept client_id, correlation_id, and payloads as
+                   keyword arguments
+        decode_fn: a method to decode a response body into response objects.
+                   The response objects must be object-like and have topic
+                   and partition attributes
+
+        Return
+        ======
+        List of response objects in the same order as the supplied payloads
+        """
+        # Get the coordinator for the consumer
+        broker = self._get_coordinator_for_consumer(group)
+        if broker is None:
+            raise CoordinatorUnavailableError(
+                "Coordinator not available for group %s" % group)
+
+        # Send the list of request payloads
+        conn = self._get_conn_for_broker(broker)
+        requestId = self._next_id()
+        request = encoder_fn(client_id=self.client_id,
+                             correlation_id=requestId, payloads=payloads)
+
+        # Send the request, recv the response
+        try:
+            conn.send(requestId, request)
+            if decoder_fn is not None:
+                try:
+                    response = conn.recv(requestId)
+                except ConnectionError, e:
+                    log.warning("Could not receive response to request [%s] "
+                                "from server %s: %s", request, conn, e)
+                    raise FailedPayloadsError(payloads)
+        except ConnectionError, e:
+            log.warning("Could not send request [%s] to server %s: %s",
+                        request, conn, e)
+            raise FailedPayloadsError(payloads)
+
+        resp = []
+        if decoder_fn is not None:
+            for response in decoder_fn(response):
+                resp.append(response)
+
+        return resp
 
     def __repr__(self):
         return '<KafkaClient client_id=%s>' % (self.client_id)
@@ -373,7 +441,7 @@ class KafkaClient(object):
         encoder = partial(KafkaProtocol.encode_offset_commit_request,
                           group=group)
         decoder = KafkaProtocol.decode_offset_commit_response
-        resps = self._send_broker_aware_request(payloads, encoder, decoder)
+        resps = self._send_consumer_aware_request(group, payloads, encoder, decoder)
 
         out = []
         for resp in resps:
@@ -392,7 +460,7 @@ class KafkaClient(object):
         encoder = partial(KafkaProtocol.encode_offset_fetch_request,
                           group=group)
         decoder = KafkaProtocol.decode_offset_fetch_response
-        resps = self._send_broker_aware_request(payloads, encoder, decoder)
+        resps = self._send_consumer_aware_request(group, payloads, encoder, decoder)
 
         out = []
         for resp in resps:

--- a/kafka/common.py
+++ b/kafka/common.py
@@ -63,6 +63,7 @@ ErrorStrings = {
     10 : 'MESSAGE_SIZE_TOO_LARGE',
     11 : 'STALE_CONTROLLER_EPOCH',
     12 : 'OFFSET_METADATA_TOO_LARGE',
+    16 : 'NOT_COORDINATOR_FOR_CONSUMER',
 }
 
 class ErrorMapping(object):
@@ -89,6 +90,10 @@ class BrokerResponseError(KafkaError):
 
 
 class LeaderUnavailableError(KafkaError):
+    pass
+
+
+class CoordinatorUnavailableError(KafkaError):
     pass
 
 

--- a/kafka/common.py
+++ b/kafka/common.py
@@ -63,6 +63,8 @@ ErrorStrings = {
     10 : 'MESSAGE_SIZE_TOO_LARGE',
     11 : 'STALE_CONTROLLER_EPOCH',
     12 : 'OFFSET_METADATA_TOO_LARGE',
+    14 : 'OFFSETS_LOAD_IN_PROGRESS',
+    15 : 'CONSUMER_COORDINATOR_NOT_AVAILABLE',
     16 : 'NOT_COORDINATOR_FOR_CONSUMER',
 }
 
@@ -90,6 +92,10 @@ class BrokerResponseError(KafkaError):
 
 
 class LeaderUnavailableError(KafkaError):
+    pass
+
+
+class OffsetLoadInProgressError(KafkaError):
     pass
 
 

--- a/kafka/common.py
+++ b/kafka/common.py
@@ -103,6 +103,10 @@ class CoordinatorUnavailableError(KafkaError):
     pass
 
 
+class ConsumerMetadataNotSupportedError(KafkaError):
+    pass
+
+
 class PartitionUnavailableError(KafkaError):
     pass
 

--- a/kafka/protocol.py
+++ b/kafka/protocol.py
@@ -10,6 +10,7 @@ from kafka.common import (
     ProduceResponse, FetchResponse, OffsetResponse,
     OffsetCommitResponse, OffsetFetchResponse,
     BufferUnderflowError, ChecksumError, ConsumerFetchSizeTooSmall,
+    OffsetLoadInProgressError, CoordinatorUnavailableError,
     ErrorMapping
 )
 from kafka.util import (
@@ -448,8 +449,10 @@ class KafkaProtocol(object):
             (host, cur) = read_short_string(data, cur)
             ((port,), cur) = relative_unpack('>i', data, cur)
             return BrokerMetadata(nodeId, host, port)
-        else:
-            return None
+        elif error_code == ErrorMapping.OFFSET_LOAD_IN_PROGRESS:
+            raise OffsetLoadInProgressError("Offset load in progress. Try again.")
+        elif error_code == ErrorMapping.CONSUMER_COORDINATOR_NOT_AVAILABLE:
+            raise CoordinatorUnavailableError("Consumer coordinator not available")
 
     @classmethod
     def encode_offset_commit_request(cls, client_id, correlation_id,


### PR DESCRIPTION
The OffsetFetchRequest and OffsetCommitRequest requests to the broker, which are used for broker storage of consumer offsets (to replace Zookeeper storage of offsets) require a ConsumerMetadataRequest. Similar to the topic metadata request, this returns the coordinator for a given consumer group, which is the broker that you must send the offset fetch and commit requests to. If you do not do this, you will more often than not get an error code 16, which is NotCoordinatorForConsumer.

I've added support for the ConsumerMetadataRequest, as well as a _send_consumer_aware_request method to support getting the coordinator and then sending a request to that broker. I have updated the OffsetFetchRequest and OffsetCommitRequest to use this method instead of the  _send_broker_aware_request method. I've also added error handling for the metadata request (in the case that it fails).