### PR TITLE
Allow MultiProcessConsumer to start each child consumer from current offset.

### DIFF
--- a/kafka/consumer/base.py
+++ b/kafka/consumer/base.py
@@ -38,7 +38,8 @@ class Consumer(object):
     """
     def __init__(self, client, group, topic, partitions=None, auto_commit=True,
                  auto_commit_every_n=AUTO_COMMIT_MSG_COUNT,
-                 auto_commit_every_t=AUTO_COMMIT_INTERVAL):
+                 auto_commit_every_t=AUTO_COMMIT_INTERVAL,
+                 load_initial_offsets=False):
 
         self.client = client
         self.topic = topic
@@ -65,7 +66,7 @@ class Consumer(object):
                                                self.commit)
             self.commit_timer.start()
 
-        if auto_commit:
+        if auto_commit or load_initial_offsets:
             self.fetch_last_known_offsets(partitions)
         else:
             for partition in partitions:

--- a/kafka/consumer/multiprocess.py
+++ b/kafka/consumer/multiprocess.py
@@ -18,7 +18,7 @@ from .simple import Consumer, SimpleConsumer
 log = logging.getLogger("kafka")
 
 
-def _mp_consume(client, group, topic, chunk, queue, start, exit, pause, size):
+def _mp_consume(client, group, topic, chunk, queue, start, exit, pause, size, load_initial_offsets):
     """
     A child process worker which consumes messages based on the
     notifications given by the controller process
@@ -37,7 +37,8 @@ def _mp_consume(client, group, topic, chunk, queue, start, exit, pause, size):
                               partitions=chunk,
                               auto_commit=False,
                               auto_commit_every_n=None,
-                              auto_commit_every_t=None)
+                              auto_commit_every_t=None,
+                              load_initial_offsets=load_initial_offsets)
 
     # Ensure that the consumer provides the partition information
     consumer.provide_partition_info()
@@ -103,7 +104,8 @@ class MultiProcessConsumer(Consumer):
     def __init__(self, client, group, topic, auto_commit=True,
                  auto_commit_every_n=AUTO_COMMIT_MSG_COUNT,
                  auto_commit_every_t=AUTO_COMMIT_INTERVAL,
-                 num_procs=1, partitions_per_proc=0):
+                 num_procs=1, partitions_per_proc=0,
+                 child_loads_initial_offsets=False):
 
         # Initiate the base consumer class
         super(MultiProcessConsumer, self).__init__(
@@ -142,7 +144,8 @@ class MultiProcessConsumer(Consumer):
             args = (client.copy(),
                     group, topic, list(chunk),
                     self.queue, self.start, self.exit,
-                    self.pause, self.size)
+                    self.pause, self.size,
+                    child_loads_initial_offsets)
 
             proc = Process(target=_mp_consume, args=args)
             proc.daemon = True

--- a/kafka/consumer/simple.py
+++ b/kafka/consumer/simple.py
@@ -98,13 +98,15 @@ class SimpleConsumer(Consumer):
                  fetch_size_bytes=FETCH_MIN_BYTES,
                  buffer_size=FETCH_BUFFER_SIZE_BYTES,
                  max_buffer_size=MAX_FETCH_BUFFER_SIZE_BYTES,
-                 iter_timeout=None):
+                 iter_timeout=None,
+                 load_initial_offsets=False):
         super(SimpleConsumer, self).__init__(
             client, group, topic,
             partitions=partitions,
             auto_commit=auto_commit,
             auto_commit_every_n=auto_commit_every_n,
-            auto_commit_every_t=auto_commit_every_t)
+            auto_commit_every_t=auto_commit_every_t,
+            load_initial_offsets=load_initial_offsets)
 
         if max_buffer_size is not None and buffer_size > max_buffer_size:
             raise ValueError("buffer_size (%d) is greater than "


### PR DESCRIPTION
Fixes mumrah/kafka-python#173.