### PR TITLE
KafkaConsumer should be in __all__.

### DIFF
--- a/kafka/__init__.py
+++ b/kafka/__init__.py
@@ -19,5 +19,5 @@ __all__ = [
     'KafkaClient', 'KafkaConnection', 'SimpleProducer', 'KeyedProducer',
     'RoundRobinPartitioner', 'HashedPartitioner', 'SimpleConsumer',
     'MultiProcessConsumer', 'create_message', 'create_gzip_message',
-    'create_snappy_message'
+    'create_snappy_message', 'KafkaConsumer',
 ]


### PR DESCRIPTION
Hey, just noticed that the new ``KafkaConsumer``is not in ``__all__`` making it hard to import. This PR fixes it :)