### PR TITLE
Use reflection to avoid multiple errno definitions

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -10,9 +10,8 @@ from kafka.common import (
     ProduceRequest, MetadataResponse,
     BrokerMetadata, TopicMetadata, PartitionMetadata,
     TopicAndPartition, KafkaUnavailableError,
-    LeaderNotAvailableError, NoError,
-    UnknownTopicOrPartitionError, KafkaTimeoutError,
-    ConnectionError
+    LeaderNotAvailableError, UnknownTopicOrPartitionError,
+    KafkaTimeoutError, ConnectionError
 )
 from kafka.conn import KafkaConnection
 from kafka.protocol import KafkaProtocol, create_message


### PR DESCRIPTION
I was searching through modifications between 0.9.0 and 0.9.1 in order to upgrade our deployed software and came across the same bug that @dpkp discovered with the check_error() method:

https://github.com/mumrah/kafka-python/commit/0d57c2718fcf3819f2c18911126f245e9e9ce3e0#diff-9e97caff580d80c9a0eb85fe22ffb3d1R184

However the fix involved creating a NoError exception which seems a bit akward. Here's a alternative version.

Cheers,
Alex