### PR TITLE
Add failed_payloads attribute to FailedPayloadsError

### DIFF
--- a/kafka/common.py
+++ b/kafka/common.py
@@ -161,7 +161,9 @@ class KafkaTimeoutError(KafkaError):
 
 
 class FailedPayloadsError(KafkaError):
-    pass
+    def __init__(self, failed_payloads, *args):
+        KafkaError.__init__(self, *args)
+        self.failed_payloads = failed_payloads
 
 
 class ConnectionError(KafkaError):


### PR DESCRIPTION
The logs and stack trace can get quite large if a payload is large, or there are a lot of them.  Moved it  to be its own attribute.