### PR TITLE
Add producer batch send queue size limit

### DIFF
--- a/kafka/common.py
+++ b/kafka/common.py
@@ -200,6 +200,10 @@ class KafkaConfigurationError(KafkaError):
     pass
 
 
+class BatchQueueOverfilledError(KafkaError):
+    pass
+
+
 def _iter_broker_errors():
     for name, obj in inspect.getmembers(sys.modules[__name__]):
         if inspect.isclass(obj) and issubclass(obj, BrokerResponseError) and obj != BrokerResponseError:

--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -195,7 +195,7 @@ class Producer(object):
             for m in msg:
                 try:
                     item = (TopicAndPartition(topic, partition), m, key)
-                    self.queue.put(item)
+                    self.queue.put_nowait(item)
                 except Full:
                     raise BatchQueueOverfilledError(
                         'Producer batch send queue overfilled. '

--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -22,7 +22,8 @@ log = logging.getLogger("kafka")
 
 BATCH_SEND_DEFAULT_INTERVAL = 20
 BATCH_SEND_MSG_COUNT = 20
-BATCH_SEND_QUEUE_MAXSIZE = 0
+# unlimited
+ASYNC_QUEUE_MAXSIZE = 0
 
 STOP_ASYNC_PRODUCER = -1
 
@@ -116,13 +117,13 @@ class Producer(object):
                  batch_send=False,
                  batch_send_every_n=BATCH_SEND_MSG_COUNT,
                  batch_send_every_t=BATCH_SEND_DEFAULT_INTERVAL,
-                 batch_send_queue_maxsize=BATCH_SEND_QUEUE_MAXSIZE):
+                 async_queue_maxsize=ASYNC_QUEUE_MAXSIZE):
 
         if batch_send:
             async = True
             assert batch_send_every_n > 0
             assert batch_send_every_t > 0
-            assert batch_send_queue_maxsize >= 0
+            assert async_queue_maxsize >= 0
         else:
             batch_send_every_n = 1
             batch_send_every_t = 3600
@@ -144,7 +145,7 @@ class Producer(object):
             log.warning("Current implementation does not retry Failed messages")
             log.warning("Use at your own risk! (or help improve with a PR!)")
             # Messages are sent through this queue
-            self.queue = Queue(maxsize=batch_send_queue_maxsize)
+            self.queue = Queue(maxsize=async_queue_maxsize)
             self.proc = Process(target=_send_upstream,
                                 args=(self.queue,
                                       self.client.copy(),

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -27,15 +27,29 @@ class TestKafkaProducer(unittest.TestCase):
             producer.send_messages(topic, partition, m)
 
     @patch('kafka.producer.base.Process')
-    def test_producer_batch_send_queue_overfilled(self, process_mock):
+    def test_producer_async_queue_overfilled_batch_send(self, process_mock):
         queue_size = 2
         producer = Producer(MagicMock(), batch_send=True,
-                            batch_send_queue_maxsize=queue_size)
+                            async_queue_maxsize=queue_size)
 
         topic = b'test-topic'
         partition = 0
-
         message = b'test-message'
+
+        with self.assertRaises(BatchQueueOverfilledError):
+            message_list = [message] * (queue_size + 1)
+            producer.send_messages(topic, partition, *message_list)
+
+    @patch('kafka.producer.base.Process')
+    def test_producer_async_queue_overfilled(self, process_mock):
+        queue_size = 2
+        producer = Producer(MagicMock(), async=True,
+                            async_queue_maxsize=queue_size)
+
+        topic = b'test-topic'
+        partition = 0
+        message = b'test-message'
+
         with self.assertRaises(BatchQueueOverfilledError):
             message_list = [message] * (queue_size + 1)
             producer.send_messages(topic, partition, *message_list)

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -2,9 +2,10 @@
 
 import logging
 
-from mock import MagicMock
+from mock import MagicMock, patch
 from . import unittest
 
+from kafka.common import BatchQueueOverfilledError
 from kafka.producer.base import Producer
 
 class TestKafkaProducer(unittest.TestCase):
@@ -25,3 +26,16 @@ class TestKafkaProducer(unittest.TestCase):
             # This should not raise an exception
             producer.send_messages(topic, partition, m)
 
+    @patch('kafka.producer.base.Process')
+    def test_producer_batch_send_queue_overfilled(self, process_mock):
+        queue_size = 2
+        producer = Producer(MagicMock(), batch_send=True,
+                            batch_send_queue_maxsize=queue_size)
+
+        topic = b'test-topic'
+        partition = 0
+
+        message = b'test-message'
+        with self.assertRaises(BatchQueueOverfilledError):
+            message_list = [message] * (queue_size + 1)
+            producer.send_messages(topic, partition, *message_list)


### PR DESCRIPTION
As noted in #297 unlimited queue size can cause memory leak.

My patches add ability to specify queue size.
By default queue size is unlimited.

If queue become full next send message will raise an `BatchQueueOverfilledError`.