### PR TITLE
Alert if the topic is not sent as bytes

### DIFF
--- a/kafka/producer/simple.py
+++ b/kafka/producer/simple.py
@@ -70,10 +70,12 @@ class SimpleProducer(Producer):
 
     def send_messages(self, topic, *msg):
         if not isinstance(topic, six.binary_type):
-            raise TypeError("topic must be type bytes")
+            topic = topic.encode('utf-8')
 
         partition = self._next_partition(topic)
-        return super(SimpleProducer, self).send_messages(topic, partition, *msg)
+        return super(SimpleProducer, self).send_messages(
+            topic, partition, *msg
+        )
 
     def __repr__(self):
         return '<SimpleProducer batch=%s>' % self.async

--- a/kafka/producer/simple.py
+++ b/kafka/producer/simple.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import random
+import six
 
 from itertools import cycle
 
@@ -68,6 +69,9 @@ class SimpleProducer(Producer):
         return next(self.partition_cycles[topic])
 
     def send_messages(self, topic, *msg):
+        if not isinstance(topic, six.binary_type):
+            raise TypeError("topic must be type bytes")
+
         partition = self._next_partition(topic)
         return super(SimpleProducer, self).send_messages(topic, partition, *msg)
 

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -7,6 +7,7 @@ from . import unittest
 
 from kafka.producer.base import Producer
 
+
 class TestKafkaProducer(unittest.TestCase):
     def test_producer_message_types(self):
 
@@ -28,11 +29,14 @@ class TestKafkaProducer(unittest.TestCase):
     def test_topic_message_types(self):
         from kafka.producer.simple import SimpleProducer
 
-        producer = SimpleProducer(MagicMock())
-        topic = "test-topic"
-        partition = 0
+        client = MagicMock()
 
-        def send_message():
-            producer.send_messages(topic, partition, b'hi')
+        def partitions(topic):
+            return [0, 1]
 
-        self.assertRaises(TypeError, send_message)
+        client.get_partition_ids_for_topic = partitions
+
+        producer = SimpleProducer(client, random_start=False)
+        topic = b"test-topic"
+        producer.send_messages(topic, b'hi')
+        assert client.send_produce_request.called

--- a/test/test_producer.py
+++ b/test/test_producer.py
@@ -25,3 +25,14 @@ class TestKafkaProducer(unittest.TestCase):
             # This should not raise an exception
             producer.send_messages(topic, partition, m)
 
+    def test_topic_message_types(self):
+        from kafka.producer.simple import SimpleProducer
+
+        producer = SimpleProducer(MagicMock())
+        topic = "test-topic"
+        partition = 0
+
+        def send_message():
+            producer.send_messages(topic, partition, b'hi')
+
+        self.assertRaises(TypeError, send_message)


### PR DESCRIPTION
Prevents people from doing the following:

```
from kafka import KafkaClient, SimpleProducer
kafka = KafkaClient(hosts=["localhost:9092"])
producer = SimpleProducer(kafka)
producer.send_messages("test", b"some message")
```

Which would give this error:
```
Traceback (most recent call last):                                                                                
  File "test_kafka.py", line 7, in <module>                                                                       
    producer.send_messages("test", b"some message")                                                               
  File "/home/sontek/venvs/notebooks3/src/kafka-python/kafka/producer/simple.py", line 71, in send_messages       
    partition = self._next_partition(topic)                                                                       
  File "/home/sontek/venvs/notebooks3/src/kafka-python/kafka/producer/simple.py", line 58, in _next_partition     
    self.client.load_metadata_for_topics(topic)                                                                   
  File "/home/sontek/venvs/notebooks3/src/kafka-python/kafka/client.py", line 309, in load_metadata_for_topics    
    resp = self.send_metadata_request(topics)                                                                     
  File "/home/sontek/venvs/notebooks3/src/kafka-python/kafka/client.py", line 378, in send_metadata_request       
    return self._send_broker_unaware_request(payloads, encoder, decoder)                                          
  File "/home/sontek/venvs/notebooks3/src/kafka-python/kafka/client.py", line 126, in _send_broker_unaware_request
    raise KafkaUnavailableError("All servers failed to process request")                                          
kafka.common.KafkaUnavailableError: All servers failed to process request                                         

```

Instead of raising a TypeError I just encode to bytes for them.

# deprecated
It now gives this error:

```
Traceback (most recent call last):                                                                              
  File "test_kafka.py", line 7, in <module>                                                                     
    producer.send_messages("test", b"some message")                                                             
  File "/home/sontek/venvs/notebooks3/src/kafka-python/kafka/producer/simple.py", line 73, in send_messages     
    raise TypeError("topic must be type bytes")                                                                 
TypeError: topic must be type bytes                                                                             
```