### PR TITLE
fix circle reference

### DIFF
--- a/kafka/util.py
+++ b/kafka/util.py
@@ -146,3 +146,4 @@ class ReentrantTimer(object):
         self.thread.join(self.t + 1)
         # noinspection PyAttributeOutsideInit
         self.timer = None
+        self.fn = None


### PR DESCRIPTION
circle reference between SimpleConsumer and ReentrantTimer .
![objgraph-icqmvd](https://cloud.githubusercontent.com/assets/4641577/5995389/a73c591a-aacc-11e4-8052-640621aceb0b.png)
