### PR TITLE
Fix python2.6 threading.Event bug in ReentrantTimer

### DIFF
--- a/kafka/util.py
+++ b/kafka/util.py
@@ -126,7 +126,11 @@ class ReentrantTimer(object):
         self.active = None
 
     def _timer(self, active):
-        while not active.wait(self.t):
+        # python2.6 Event.wait() always returns None
+        # python2.7 and greater returns the flag value (true/false)
+        # we want the flag value, so add an 'or' here for python2.6
+        # this is redundant for later python versions (FLAG OR FLAG == FLAG)
+        while not (active.wait(self.t) or active.is_set()):
             self.fn(*self.args, **self.kwargs)
 
     def start(self):


### PR DESCRIPTION
threading.Event.wait return values are different for python2.6
https://docs.python.org/2/library/threading.html#threading.Event.wait
this causes the current reentrant timer to never stop when using python2.6