### PR TITLE
Always return sorted partition ids in client.get_partition_ids_for_topic()

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -261,7 +261,7 @@ class KafkaClient(object):
         if topic not in self.topic_partitions:
             return None
 
-        return list(self.topic_partitions[topic])
+        return sorted(list(self.topic_partitions[topic]))
 
     def ensure_topic_exists(self, topic, timeout = 30):
         start_time = time.time()


### PR DESCRIPTION
should fix the travis-ci build failures, caused by new behavior in pypy 2.5.0
list({1: 'foo', 0: 'bar'})
pypy: [1, 0]
py27: [0, 1]
which was causing chaos with the tests