### PR TITLE
Switch to rst and use in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Kafka Python client
 ------------------------
 .. image:: https://api.travis-ci.org/mumrah/kafka-python.png?branch=master
-    :target: https://travis-ci.org/mumrah/kafka-pytho
+    :target: https://travis-ci.org/mumrah/kafka-python
     :alt: Build Status
 
 .. image:: https://api.travis-ci.org/mumrah/kafka-python.png?branch=master
@@ -12,7 +12,7 @@ Kafka Python client
     :target: http://kafka-python.readthedocs.org/en/latest/
     :alt: Full documentation available on ReadTheDocs
 
-`Full documentation available on ReadTheDoc`_
+`Full documentation available on ReadTheDocs`_
 
 This module provides low-level protocol support for Apache Kafka as well as
 high-level consumer and producer classes. Request batching is supported by the
@@ -26,13 +26,13 @@ On Freenode IRC at #kafka-python, as well as #apache-kafka
 For general discussion of kafka-client design and implementation (not python specific),
 see https://groups.google.com/forum/#!forum/kafka-clients
 
-# License
-
+License
+----------
 Copyright 2015, David Arthur under Apache License, v2.0. See `LICENSE`
 
-# Status
-
-The current stable version of this package is **`0.9.3`_** and is compatible with:
+Status
+----------
+The current stable version of this package is **0.9.3_** and is compatible with:
 
 Kafka broker versions
 - 0.8.2.0 [offset management currently ZK only -- does not support ConsumerCoordinator offset management APIs]

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,18 @@
-# Kafka Python client
+Kafka Python client
+------------------------
+.. image:: https://api.travis-ci.org/mumrah/kafka-python.png?branch=master
+    :target: https://travis-ci.org/mumrah/kafka-pytho
+    :alt: Build Status
 
-[![Build Status](https://api.travis-ci.org/mumrah/kafka-python.png?branch=master)](https://travis-ci.org/mumrah/kafka-python)
-[![Coverage Status](https://coveralls.io/repos/mumrah/kafka-python/badge.svg?branch=master)](https://coveralls.io/r/mumrah/kafka-python?branch=master)
-[![Full documentation available on ReadTheDocs](https://readthedocs.org/projects/kafka-python/badge/?version=latest)](https://readthedocs.org/projects/kafka-python/?badge=latest)
+.. image:: https://api.travis-ci.org/mumrah/kafka-python.png?branch=master
+    :target: https://coveralls.io/repos/mumrah/kafka-python/badge.svg?branch=master
+    :alt: Coverage Status
 
-[Full documentation available on ReadTheDocs](http://kafka-python.readthedocs.org/en/latest/) 
+.. image:: https://readthedocs.org/projects/kafka-python/badge/?version=latest
+    :target: http://kafka-python.readthedocs.org/en/latest/
+    :alt: Full documentation available on ReadTheDocs
+
+`Full documentation available on ReadTheDoc`_
 
 This module provides low-level protocol support for Apache Kafka as well as
 high-level consumer and producer classes. Request batching is supported by the
@@ -24,7 +32,7 @@ Copyright 2015, David Arthur under Apache License, v2.0. See `LICENSE`
 
 # Status
 
-The current stable version of this package is [**0.9.3**](https://github.com/mumrah/kafka-python/releases/tag/v0.9.3) and is compatible with
+The current stable version of this package is **`0.9.3`_** and is compatible with:
 
 Kafka broker versions
 - 0.8.2.0 [offset management currently ZK only -- does not support ConsumerCoordinator offset management APIs]
@@ -38,3 +46,6 @@ Python versions
 - 3.3 (tested on 3.3.5)
 - 3.4 (tested on 3.4.2)
 - pypy (tested on pypy 2.4.0 / python 2.7.8)
+
+.. _Full documentation available on ReadTheDocs: http://kafka-python.readthedocs.org/en/latest/
+.. _0.9.3: https://github.com/mumrah/kafka-python/releases/tag/v0.9.3

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Kafka Python client
     :target: https://travis-ci.org/mumrah/kafka-python
     :alt: Build Status
 
-.. image:: https://coveralls.io/r/mumrah/kafka-python?branch=master
-    :target: https://coveralls.io/repos/mumrah/kafka-python/badge.svg?branch=master
+.. image:: https://coveralls.io/repos/mumrah/kafka-python/badge.svg?branch=master
+    :target: https://coveralls.io/r/mumrah/kafka-python?branch=master
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/kafka-python/badge/?version=latest
@@ -35,12 +35,14 @@ Status
 The current stable version of this package is `0.9.3`_ and is compatible with:
 
 Kafka broker versions
+
 - 0.8.2.0 [offset management currently ZK only -- does not support ConsumerCoordinator offset management APIs]
 - 0.8.1.1
 - 0.8.1
 - 0.8.0
 
 Python versions
+
 - 2.6 (tested on 2.6.9)
 - 2.7 (tested on 2.7.9)
 - 3.3 (tested on 3.3.5)

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Kafka Python client
     :target: https://travis-ci.org/mumrah/kafka-python
     :alt: Build Status
 
-.. image:: https://api.travis-ci.org/mumrah/kafka-python.png?branch=master
+.. image:: https://coveralls.io/r/mumrah/kafka-python?branch=master
     :target: https://coveralls.io/repos/mumrah/kafka-python/badge.svg?branch=master
     :alt: Coverage Status
 
@@ -32,7 +32,7 @@ Copyright 2015, David Arthur under Apache License, v2.0. See `LICENSE`
 
 Status
 ----------
-The current stable version of this package is **0.9.3_** and is compatible with:
+The current stable version of this package is `0.9.3`_ and is compatible with:
 
 Kafka broker versions
 - 0.8.2.0 [offset management currently ZK only -- does not support ConsumerCoordinator offset management APIs]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import sys
-
+import os
 from setuptools import setup, Command
 
 with open('VERSION', 'r') as v:
@@ -26,6 +26,10 @@ test_require = ['tox', 'mock']
 if sys.version_info < (2, 7):
     test_require.append('unittest2')
 
+here = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(here, 'README.rst')) as f:
+    README = f.read()
 
 setup(
     name="kafka-python",
@@ -46,15 +50,10 @@ setup(
     url="https://github.com/mumrah/kafka-python",
     license="Apache License 2.0",
     description="Pure Python client for Apache Kafka",
-    long_description="""
-This module provides low-level protocol support for Apache Kafka as well as
-high-level consumer and producer classes. Request batching is supported by the
-protocol as well as broker-aware request routing. Gzip and Snappy compression
-is also supported for message sets.
-""",
+    long_description=README,
     keywords="apache kafka",
     install_requires=['six'],
-    classifiers = [
+    classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ]


### PR DESCRIPTION
This allows us to have our README show up on pypi.  https://pypi.python.org/pypi/kafka-python doesn't look as nice as it will with this change :)