### PR TITLE
Properly destroying the objects that contain daemonized threads

### DIFF
--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -127,6 +127,7 @@ class Producer(object):
         self.async = async
         self.req_acks = req_acks
         self.ack_timeout = ack_timeout
+        self.stopped = False
 
         if codec is None:
             codec = CODEC_NONE
@@ -212,3 +213,8 @@ class Producer(object):
 
             if self.proc.is_alive():
                 self.proc.terminate()
+        self.stopped = True
+
+    def __del__(self):
+        if not self.stopped:
+            self.stop()

--- a/kafka/util.py
+++ b/kafka/util.py
@@ -151,3 +151,6 @@ class ReentrantTimer(object):
         # noinspection PyAttributeOutsideInit
         self.timer = None
         self.fn = None
+
+    def __del__(self):
+        self.stop()


### PR DESCRIPTION
Consumer, Producer and ReentrantTimer all create daemonized threads. Problem: when destroying these objects, the daemonized threads are not destroyed and the threads live forever with no mean to reach them.

This created issue #323, which I could deal with by using stop() manually, but there is no reason to force the user to force the user to do that when it could be dealt with automatically.

This pull request fixes this.