### PR TITLE
Wrong partitions distribution logic for MP Consumer

### DIFF
--- a/kafka/consumer/multiprocess.py
+++ b/kafka/consumer/multiprocess.py
@@ -131,7 +131,7 @@ class MultiProcessConsumer(Consumer):
         # * we have an even distribution of partitions among processes
         if not partitions_per_proc:
             partitions_per_proc = round(len(partitions) * 1.0 / num_procs)
-            if partitions_per_proc < num_procs * 0.5:
+            if partitions_per_proc * num_procs < len(partitions):
                 partitions_per_proc += 1
 
         # The final set of chunks

--- a/kafka/consumer/multiprocess.py
+++ b/kafka/consumer/multiprocess.py
@@ -123,26 +123,25 @@ class MultiProcessConsumer(Consumer):
         self.pause = Event()        # Requests the consumers to pause fetch
         self.size = Value('i', 0)   # Indicator of number of messages to fetch
 
-        partitions = self.offsets.keys()
+        partitions = list(self.offsets.keys())
 
-        # If unspecified, start one consumer per partition
+        # By default, start one consumer process for all partitions
         # The logic below ensures that
         # * we do not cross the num_procs limit
         # * we have an even distribution of partitions among processes
-        if not partitions_per_proc:
-            partitions_per_proc = round(len(partitions) * 1.0 / num_procs)
-            if partitions_per_proc * num_procs < len(partitions):
-                partitions_per_proc += 1
+
+        if partitions_per_proc:
+            num_procs = len(partitions) / partitions_per_proc
+            if num_procs * partitions_per_proc < len(partitions):
+                num_procs += 1
 
         # The final set of chunks
-        chunker = lambda *x: [] + list(x)
-        chunks = map(chunker, *[iter(partitions)] * int(partitions_per_proc))
+        chunks = [partitions[proc::num_procs] for proc in range(num_procs)]
 
         self.procs = []
         for chunk in chunks:
-            chunk = filter(lambda x: x is not None, chunk)
             args = (client.copy(),
-                    group, topic, list(chunk),
+                    group, topic, chunk,
                     self.queue, self.start, self.exit,
                     self.pause, self.size)
 

--- a/kafka/consumer/multiprocess.py
+++ b/kafka/consumer/multiprocess.py
@@ -123,7 +123,10 @@ class MultiProcessConsumer(Consumer):
         self.pause = Event()        # Requests the consumers to pause fetch
         self.size = Value('i', 0)   # Indicator of number of messages to fetch
 
-        partitions = list(self.offsets.keys())
+        # dict.keys() returns a view in py3 + it's not a thread-safe operation
+        # http://blog.labix.org/2008/06/27/watch-out-for-listdictkeys-in-python-3
+        # It's safer to copy dict as it only runs during the init.
+        partitions = list(self.offsets.copy().keys())
 
         # By default, start one consumer process for all partitions
         # The logic below ensures that


### PR DESCRIPTION
I could be wrong, but it seems that there's wrong partitions distribution logic for `MultiProcessConsumer`.
It's not even at all currently, it can be checked with the following function (cut from the code and wrapped):
```python 
>>> def get_chunks(partitions, num_procs, partitions_per_proc=0):
...     if not partitions_per_proc:
...             partitions_per_proc = round(len(partitions) * 1.0 / num_procs)
...             if partitions_per_proc < num_procs * 0.5:
...                     partitions_per_proc += 1
...     chunker = lambda *x: [] + list(x)
...     return map(chunker, *[iter(partitions)] * int(partitions_per_proc))
...
```
Wrong cases examples:
```python
>>> get_chunks(range(16), 3)
[[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14], [15, None, None, None, None]]
# there should be 3 chunks!
>>> get_chunks(range(16), 8)
[[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [12, 13, 14], [15, None, None]]
# there should be 8 chunks by 2 partitions each
```
This PR solves this issue by fixing the condition when we should increase `partitions_per_proc` by 1:
```python
>>> get_chunks(range(16), 1)
[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]]
>>> get_chunks(range(16), 2)
[[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]]
>>> get_chunks(range(16), 3)
[[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10, 11], [12, 13, 14, 15, None, None]]
>>> get_chunks(range(16), 4)
[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
>>> get_chunks(range(16), 8)
[[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [10, 11], [12, 13], [14, 15]]
```