### PR TITLE
rollover correlation id. addresses #344

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -2,11 +2,11 @@ import binascii
 import collections
 import copy
 import functools
-import itertools
 import logging
 import time
 import kafka.common
 
+from ctypes import c_uint32
 from kafka.common import (TopicAndPartition, BrokerMetadata,
                           ConnectionError, FailedPayloadsError,
                           KafkaTimeoutError, KafkaUnavailableError,
@@ -23,7 +23,7 @@ log = logging.getLogger("kafka")
 class KafkaClient(object):
 
     CLIENT_ID = b"kafka-python"
-    ID_GEN = itertools.count()
+    ID_GEN = 0
 
     # NOTE: The timeout given to the client should always be greater than the
     # one passed to SimpleConsumer.get_message(), otherwise you can get a
@@ -101,7 +101,8 @@ class KafkaClient(object):
         """
         Generate a new correlation id
         """
-        return next(KafkaClient.ID_GEN)
+        KafkaClient.ID_GEN = c_uint32(KafkaClient.ID_GEN + 1).value
+        return KafkaClient.ID_GEN
 
     def _send_broker_unaware_request(self, payloads, encoder_fn, decoder_fn):
         """

--- a/kafka/protocol.py
+++ b/kafka/protocol.py
@@ -52,7 +52,7 @@ class KafkaProtocol(object):
         """
         Encode the common request envelope
         """
-        return struct.pack('>hhih%ds' % len(client_id),
+        return struct.pack('>hhIh%ds' % len(client_id),
                            request_key,          # ApiKey
                            0,                    # ApiVersion
                            correlation_id,       # CorrelationId


### PR DESCRIPTION
when the correlation id hits 2,147,483,648 (one over int32 MAX), then the driver can't encode that message, and hits an error.

So in this changed I've done two things.

1. change the encoder to use an unsigned number from a signed for the correlation_id
2. removed itertools and replaced it with a normal python integer, with every _next() call converting the number to a ctype uint_32 to allow for an overflow to roll over back down to 0.

Not sure if this is the better design choice than just doing a check of itertools.count to see if it hit the intmax, then resetting it.