### PR TITLE
Enable commit on seek

### DIFF
--- a/kafka/consumer/simple.py
+++ b/kafka/consumer/simple.py
@@ -214,8 +214,8 @@ class SimpleConsumer(Consumer):
 
         # Reset queue and fetch offsets since they are invalid
         self.fetch_offsets = self.offsets.copy()
+        self.count_since_commit += 1
         if self.auto_commit:
-            self.count_since_commit += 1
             self.commit()
 
         self.queue = Queue()


### PR DESCRIPTION
This change enables an explicit call to
commit() to actually commit the offsets even if auto_commit is False. Currently a consumer is not
able to commit the offsets after a seek until at least one message is read.