### PR TITLE
Allow consumers to control start from beginning behavior

### DIFF
--- a/kafka/consumer/base.py
+++ b/kafka/consumer/base.py
@@ -40,7 +40,8 @@ class Consumer(object):
     """
     def __init__(self, client, group, topic, partitions=None, auto_commit=True,
                  auto_commit_every_n=AUTO_COMMIT_MSG_COUNT,
-                 auto_commit_every_t=AUTO_COMMIT_INTERVAL):
+                 auto_commit_every_t=AUTO_COMMIT_INTERVAL,
+                 start_from_beginning=True):
 
         self.client = client
         self.topic = topic
@@ -67,7 +68,7 @@ class Consumer(object):
                                                self.commit)
             self.commit_timer.start()
 
-        if auto_commit:
+        if auto_commit or not start_from_beginning:
             self.fetch_last_known_offsets(partitions)
         else:
             for partition in partitions:

--- a/kafka/consumer/simple.py
+++ b/kafka/consumer/simple.py
@@ -114,13 +114,15 @@ class SimpleConsumer(Consumer):
                  buffer_size=FETCH_BUFFER_SIZE_BYTES,
                  max_buffer_size=MAX_FETCH_BUFFER_SIZE_BYTES,
                  iter_timeout=None,
-                 auto_offset_reset='largest'):
+                 auto_offset_reset='largest',
+                 start_from_beginning=True):
         super(SimpleConsumer, self).__init__(
             client, group, topic,
             partitions=partitions,
             auto_commit=auto_commit,
             auto_commit_every_n=auto_commit_every_n,
-            auto_commit_every_t=auto_commit_every_t)
+            auto_commit_every_t=auto_commit_every_t,
+            start_from_beginning=start_from_beginning)
 
         if max_buffer_size is not None and buffer_size > max_buffer_size:
             raise ValueError("buffer_size (%d) is greater than "


### PR DESCRIPTION
Clients of the multi-process consumer currently have no way of enforcing that the consumer resumes from the last committed offset.  `SimpleConsumer` automatically receives this behaviour when `auto_commit` is enabled and can explicitly request the offset using `fetch_last_known_offsets`. 

To ensure backward compatibility a `start_from_beginning` parameter has been added to the base consumer which defaults to `True`. 

Reference: #347 