### PR TITLE
MultiProcessConsumer: an option to use current offsets 

### DIFF
--- a/kafka/consumer/base.py
+++ b/kafka/consumer/base.py
@@ -40,7 +40,8 @@ class Consumer(object):
     """
     def __init__(self, client, group, topic, partitions=None, auto_commit=True,
                  auto_commit_every_n=AUTO_COMMIT_MSG_COUNT,
-                 auto_commit_every_t=AUTO_COMMIT_INTERVAL):
+                 auto_commit_every_t=AUTO_COMMIT_INTERVAL,
+                 load_initial_offsets=False):
 
         self.client = client
         self.topic = topic
@@ -67,7 +68,7 @@ class Consumer(object):
                                                self.commit)
             self.commit_timer.start()
 
-        if auto_commit:
+        if auto_commit or load_initial_offsets:
             self.fetch_last_known_offsets(partitions)
         else:
             for partition in partitions:

--- a/kafka/consumer/multiprocess.py
+++ b/kafka/consumer/multiprocess.py
@@ -115,7 +115,8 @@ class MultiProcessConsumer(Consumer):
             partitions=None,
             auto_commit=auto_commit,
             auto_commit_every_n=auto_commit_every_n,
-            auto_commit_every_t=auto_commit_every_t)
+            auto_commit_every_t=auto_commit_every_t,
+            load_initial_offsets=child_loads_initial_offsets)
 
         # Variables for managing and controlling the data flow from
         # consumer child process to master

--- a/kafka/consumer/simple.py
+++ b/kafka/consumer/simple.py
@@ -114,13 +114,16 @@ class SimpleConsumer(Consumer):
                  buffer_size=FETCH_BUFFER_SIZE_BYTES,
                  max_buffer_size=MAX_FETCH_BUFFER_SIZE_BYTES,
                  iter_timeout=None,
-                 auto_offset_reset='largest'):
+                 auto_offset_reset='largest',
+                 load_initial_offsets=False):
+
         super(SimpleConsumer, self).__init__(
             client, group, topic,
             partitions=partitions,
             auto_commit=auto_commit,
             auto_commit_every_n=auto_commit_every_n,
-            auto_commit_every_t=auto_commit_every_t)
+            auto_commit_every_t=auto_commit_every_t,
+            load_initial_offsets=load_initial_offsets)
 
         if max_buffer_size is not None and buffer_size > max_buffer_size:
             raise ValueError("buffer_size (%d) is greater than "

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -127,7 +127,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         with self.assertRaises(OffsetOutOfRangeError):
             consumer.get_message()
 
-    @kafka_versions('all')
+    @kafka_versions("0.8.1", "0.8.1.1", "0.8.2.0")
     def test_simple_consumer_load_initial_offsets(self):
         self.send_messages(0, range(0, 100))
         self.send_messages(1, range(100, 200))
@@ -268,7 +268,7 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
 
         consumer.stop()
 
-    @kafka_versions("all")
+    @kafka_versions("0.8.1", "0.8.1.1", "0.8.2.0")
     def test_multi_process_consumer_load_initial_offsets(self):
         self.send_messages(0, range(0, 10))
         self.send_messages(1, range(10, 20))

--- a/test/test_consumer_integration.py
+++ b/test/test_consumer_integration.py
@@ -127,6 +127,23 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         with self.assertRaises(OffsetOutOfRangeError):
             consumer.get_message()
 
+    @kafka_versions('all')
+    def test_simple_consumer_load_initial_offsets(self):
+        self.send_messages(0, range(0, 100))
+        self.send_messages(1, range(100, 200))
+
+        # Create 1st consumer and change offsets
+        consumer = self.consumer()
+        self.assertEqual(consumer.offsets, {0: 0, 1: 0})
+        consumer.offsets.update({0:51, 1:101})
+        # Update counter after manual offsets update
+        consumer.count_since_commit += 1
+        consumer.commit()
+
+        # Create 2nd consumer and check initial offsets
+        consumer = self.consumer(load_initial_offsets=True, auto_commit=False)
+        self.assertEqual(consumer.offsets, {0: 51, 1: 101})
+
     @kafka_versions("all")
     def test_simple_consumer__seek(self):
         self.send_messages(0, range(0, 100))
@@ -250,6 +267,25 @@ class TestConsumerIntegration(KafkaIntegrationTestCase):
         self.assertEqual(consumer.pending(partitions=[1]), 10)
 
         consumer.stop()
+
+    @kafka_versions("all")
+    def test_multi_process_consumer_load_initial_offsets(self):
+        self.send_messages(0, range(0, 10))
+        self.send_messages(1, range(10, 20))
+
+        # Create 1st consumer and change offsets
+        consumer = self.consumer()
+        self.assertEqual(consumer.offsets, {0: 0, 1: 0})
+        consumer.offsets.update({0:5, 1:15})
+        # Update counter after manual offsets update
+        consumer.count_since_commit += 1
+        consumer.commit()
+
+        # Create 2nd consumer and check initial offsets
+        consumer = self.consumer(consumer = MultiProcessConsumer,
+                                 auto_commit=False,
+                                 child_loads_initial_offsets=True)
+        self.assertEqual(consumer.offsets, {0: 5, 1: 15})
 
     @kafka_versions("all")
     def test_large_messages(self):


### PR DESCRIPTION
It's continuation of #252 (fixes #173) with a small additional fix and a couple of base tests. This is an annoyance that so far current `MultiProcessConsumer` starts from 0 offsets each time, I braced myself the courage to finish it. The only moment here - I'm not sure about correct beautiful names for options, probably someone have a better idea. 