### PR TITLE
Stop consumers on delete

### DIFF
--- a/kafka/consumer/base.py
+++ b/kafka/consumer/base.py
@@ -143,6 +143,9 @@ class Consumer(object):
         if self.count_since_commit >= self.auto_commit_every_n:
             self.commit()
 
+    def __del__(self):
+        self.stop()
+
     def stop(self):
         if self.commit_timer is not None:
             self.commit_timer.stop()


### PR DESCRIPTION
consumer.stop() is used to cleanup threads / processes.  This change is intended to cleanup multiprocess consumers which previously seem to have been just garbage collected.  It will also cause the autocommit batch timer to commit on delete.