### PR TITLE
KafkaConsumer topic/partition fixes

### DIFF
--- a/kafka/consumer/kafka.py
+++ b/kafka/consumer/kafka.py
@@ -224,7 +224,7 @@ class KafkaConsumer(object):
                         topic = kafka_bytestring(key[0])
                         partition = key[1]
                         self._consume_topic_partition(topic, partition)
-                        self._offsets.fetch[key] = value
+                        self._offsets.fetch[(topic, partition)] = value
 
             else:
                 raise KafkaConfigurationError('Unknown topic type (%s)' % type(arg))

--- a/kafka/consumer/kafka.py
+++ b/kafka/consumer/kafka.py
@@ -194,10 +194,10 @@ class KafkaConsumer(object):
             elif isinstance(arg, tuple):
                 topic = kafka_bytestring(arg[0])
                 partition = arg[1]
+                self._consume_topic_partition(topic, partition)
                 if len(arg) == 3:
                     offset = arg[2]
                     self._offsets.fetch[(topic, partition)] = offset
-                self._consume_topic_partition(topic, partition)
 
             # { topic: partitions, ... } dict
             elif isinstance(arg, dict):


### PR DESCRIPTION
Fix a str/bytes bug set_topic_partitions when using { (topic,...... partition): offset, } interface
Some small cleanups in fetch_messages to topic/partition handling
