### PR TITLE
Fix calling of _offsets

### DIFF
--- a/kafka/consumer/kafka.py
+++ b/kafka/consumer/kafka.py
@@ -344,7 +344,7 @@ class KafkaConsumer(object):
                 logger.warning('OffsetOutOfRange: topic %s, partition %d, '
                                'offset %d (Highwatermark: %d)',
                                topic, partition,
-                               self.offsets._fetch[(topic, partition)],
+                               self._offsets.fetch[(topic, partition)],
                                resp.highwaterMark)
                 # Reset offset
                 self._offsets.fetch[(topic, partition)] = (


### PR DESCRIPTION
Previously you would see this error:
```
self.offsets._fetch[(topic, partition)],
AttributeError: 'function' object has no attribute '_fetch'
```