### PR TITLE
Lower logging level on replica not available and commit

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -409,7 +409,7 @@ class KafkaClient(object):
                 # this error code is provided for admin purposes only
                 # we never talk to replicas, only the leader
                 except ReplicaNotAvailableError:
-                    log.warning('Some (non-leader) replicas not available for topic %s partition %d', topic, partition)
+                    log.debug('Some (non-leader) replicas not available for topic %s partition %d', topic, partition)
 
                 # If Known Broker, topic_partition -> BrokerMetadata
                 if leader in self.brokers:

--- a/kafka/consumer/base.py
+++ b/kafka/consumer/base.py
@@ -138,7 +138,7 @@ class Consumer(object):
             if partitions is None:  # commit all partitions
                 partitions = list(self.offsets.keys())
 
-            log.info('Committing new offsets for %s, partitions %s',
+            log.debug('Committing new offsets for %s, partitions %s',
                      self.topic, partitions)
             for partition in partitions:
                 offset = self.offsets[partition]


### PR DESCRIPTION
These two log prints are very noisy when we deal with high volume topics and large clusters, and in my opinion not particularly useful from a client perspective unless in debug level.
The replica not available log, indeed, is not specific of the topic/partition of the particular consumer/producer. In a Kafka cluster with a lots of topics this ends up flooding the logs with warning about under replicated topics which the user most of the times is not interested in. This is a very important information for the cluster administrator, but the latter should rely on metrics and logging provided by Kafka itself instead of a client library.