### PR TITLE
Catch KafkaUnavailableError in _send_broker_aware_request

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -171,7 +171,7 @@ class KafkaClient(object):
                 log.warning('KafkaUnavailableError attempting to send request '
                             'on topic %s partition %d', payload.topic, payload.partition)
                 topic_partition = (payload.topic, payload.partition)
-                responses[topic_partition] = FailedPayloadsErrors(payload)
+                responses[topic_partition] = FailedPayloadsError(payload)
 
         # For each broker, send the list of request payloads
         # and collect the responses and errors

--- a/kafka/client.py
+++ b/kafka/client.py
@@ -161,6 +161,7 @@ class KafkaClient(object):
         brokers_for_payloads = []
         payloads_by_broker = collections.defaultdict(list)
 
+        responses = {}
         for payload in payloads:
             try:
                 leader = self._get_leader_for_partition(payload.topic,
@@ -175,7 +176,6 @@ class KafkaClient(object):
 
         # For each broker, send the list of request payloads
         # and collect the responses and errors
-        responses = {}
         broker_failures = []
         for broker, payloads in payloads_by_broker.items():
             requestId = self._next_id()


### PR DESCRIPTION
The caller is expecting failure responses, not thrown exceptions; make sure to catch exceptions from calls that might provoke a metadata request.

This avoids send_produce_request unexpectedly throwing an exception, which ends up killing the async producer thread.

Fixes issue #429 