### PR TITLE
Prevents crashing communication thread of async producer

### DIFF
--- a/kafka/client.py
+++ b/kafka/client.py
@@ -7,7 +7,7 @@ import time
 import kafka.common
 from kafka.common import (TopicAndPartition, BrokerMetadata,
                           ConnectionError, FailedPayloadsError,
-                          KafkaTimeoutError, KafkaUnavailableError,
+                          KafkaTimeoutError, KafkaUnavailableError, KafkaError,
                           LeaderNotAvailableError, UnknownTopicOrPartitionError,
                           NotLeaderForPartitionError, ReplicaNotAvailableError)
 
@@ -168,9 +168,8 @@ class KafkaClient(object):
                                                         payload.partition)
                 payloads_by_broker[leader].append(payload)
                 brokers_for_payloads.append(leader)
-            except KafkaUnavailableError as e:
-                log.warning('KafkaUnavailableError attempting to send request '
-                            'on topic %s partition %d', payload.topic, payload.partition)
+            except KafkaError as e:
+                log.warning('Error attempting to send request: ' + e.message)
                 topic_partition = (payload.topic, payload.partition)
                 responses[topic_partition] = FailedPayloadsError(payload)
 

--- a/kafka/producer/base.py
+++ b/kafka/producer/base.py
@@ -185,7 +185,10 @@ def _send_upstream(queue, client, codec, batch_time, batch_size,
         # refresh topic metadata before next retry
         if retry_state['do_refresh']:
             log.warn('Async producer forcing metadata refresh metadata before retrying')
-            client.load_metadata_for_topics()
+            try:
+                client.load_metadata_for_topics()
+            except Exception as e:
+                log.error("Async producer couldn't reload topic metadata: " + e.message)
 
         # Apply retry limit, dropping messages that are over
         request_tries = dict(


### PR DESCRIPTION
If an uncaught exception occurs in _send_messages() the thread sending
data to Kafka (asynchronously) will crash and the queue will never be
emptied. To reproduce:
1) Run an Async producer.
2) Kill the Kafka server.
3) Restart the Kafka server.
The communication thread dies shortly after step 2. After step 3 the
communication does not resume without this commit.

The change in `KafkaClient::_send_broker_aware_request()` prevents an
exception from being thrown when it's called by
`KafkaClient::send_produce_request()` with `fail_on_error=False`.
Other exceptions besides `KafkaUnavailableError` that can be thrown include:
`LeaderNotAvailableError`, `UnknownTopicOrPartitionError` and 
`UnknownTopicOrPartitionError`.

The try/except in `KafkaClient::_send_broker_unaware_request()` prevents
an exception to crash the communication thread.